### PR TITLE
Scroll to the bottom when Q&A changes

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -26,6 +26,7 @@
                     </div>`;
 
                 document.getElementById("in-progress")?.classList?.remove("hidden");
+                list.scrollTo(0, list.scrollHeight);
                 break;
             case "addResponse":
                 document.getElementById("in-progress")?.classList?.add("hidden");
@@ -39,6 +40,7 @@
                         <div>${marked.parse(message.value)}</div>
                     </div>`;
 
+                list.scrollTo(0, list.scrollHeight);
                 break;
             default:
                 break;


### PR DESCRIPTION
This is a small quality of life improvement so you can see the question you asked and the response immediately, instead of having to manually scroll down the chat log.