### PR TITLE
Pass userAgent to ChatGPTAPI, now works (tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Open the VS Code Command Palette and Type `ChatGPT: Reset token`, this will prom
 
 To get the tokens:
 
-1. Go to https://chat.openai.com/chat and log in or sign up.
+1. Go to https://chat.openai.com/chat and log in or sign up (preferably in a browser other then Chrome, see below).
 2. Open dev tools.
 3. Open `Application` > `Cookies` (`Storage` > `Cookies` on FireFox)
    
@@ -39,7 +39,8 @@ To get the tokens:
 
 *Once you're logged in, you can ask ChatGPT any question and supply source code from your current file/selection.*
 
-(Because of cloudflare, there are now several limitations, see [here](https://github.com/timkmecl/chatgpt-vscode#update-december-12-2022) for more)
+- Because of cloudflare, there are now several limitations, see [here](https://github.com/timkmecl/chatgpt-vscode#update-december-12-2022) for more.
+- There are currently users who have issues even when following all of the above (see this [comment](https://github.com/timkmecl/chatgpt-vscode/issues/4#issuecomment-1350562961)). **If you're using Chrome to obtain the tokens, try using a different browser** (e.g. Brave), as it seems like using Chrome is often the cause of this.
 
 ## Support
 If you need help using this extension, please open an issue on the GitHub repository for this extension.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ To get the tokens:
 
 *Once you're logged in, you can ask ChatGPT any question and supply source code from your current file/selection.*
 
+(Because of cloudflare, there are now several limitations, see [here](https://github.com/timkmecl/chatgpt-vscode#update-december-12-2022) for more)
+
 ## Support
 If you need help using this extension, please open an issue on the GitHub repository for this extension.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-vscode-plugin",
-  "version": "1.1.6",
+  "version": "1.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-vscode-plugin",
-      "version": "1.1.6",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "chatgpt": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "publisher": "JayBarnes",
   "displayName": "ChatGPT VSCode Plugin",
   "description": "A ChatGPT integration build using ChatGPT & 9 beers",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "engines": {
     "vscode": "^1.73.0"
   },

--- a/src/chatgpt-view-provider.ts
+++ b/src/chatgpt-view-provider.ts
@@ -82,7 +82,8 @@ export default class ChatGptViewProvider implements vscode.WebviewViewProvider {
             try {
                 this.chatGptApi = new ChatGPTAPI({
                     sessionToken: this.sessionToken as string,
-                    clearanceToken: this.clearanceToken as string
+                    clearanceToken: this.clearanceToken as string,
+                    userAgent: this.userAgent as string
                 });
                 this.chatGptConversaion = this.chatGptApi?.getConversation();
             } catch (error: any) {


### PR DESCRIPTION
Fixes #22.
I've forgotten to commit this into previous PR #24, now tested and works.
Link to the fork if you want to try it before it is merged: https://github.com/timkmecl/chatgpt-vscode-plugin

If you still get the 403 Error despite following the instructions and are using Chrome to get the tokens, try using some other browser (see [this](https://github.com/barnesoir/chatgpt-vscode-plugin/issues/22#issuecomment-1350798191))
